### PR TITLE
FIX Capture duplicate suggestion exception

### DIFF
--- a/code/services/ExtensibleSearchService.php
+++ b/code/services/ExtensibleSearchService.php
@@ -87,7 +87,16 @@ class ExtensibleSearchService {
 				'ExtensibleSearchPageID' => $pageID
 			));
 		}
-		$suggestion->write();
+		
+		try {
+            	    $suggestion->write();
+        	} catch (ValidationException $ex) {
+	            // we're not too fussed if this doesn't save, and we don't need to 
+	            // do anything if it doesn't. 
+	            error_log($ex->getTraceAsString());
+	            return null;
+                }
+                
 		return $suggestion;
 	}
 


### PR DESCRIPTION
Captures any validation exception thrown and rather than failing the full request, logs the error and returns. 

Not sure on the underlying conditions of the duplicate detection occurring, but this prevents that failure causing white-screen-of-death
