### PR TITLE
fix(SearchPage) - fix history query for mysql 5.7+

### DIFF
--- a/code/pages/ExtensibleSearchPage.php
+++ b/code/pages/ExtensibleSearchPage.php
@@ -444,14 +444,14 @@ class ExtensibleSearchPage extends Page {
 
 		$history = $this->History();
 		$query = new SQLSelect(
-			"Term, COUNT(*) AS Frequency, ((COUNT(*) * 100.00) / {$history->count()}) AS FrequencyPercentage, AVG(Time) AS AverageTimeTaken, (Results > 0) AS Results",
+			"Term, COUNT(*) AS Frequency, ((COUNT(*) * 100.00) / {$history->count()}) AS FrequencyPercentage, AVG(Time) AS AverageTimeTaken, (Results > 0) AS HasResults",
 			'ExtensibleSearch',
 			"ExtensibleSearchPageID = {$this->ID}",
 			array(
 				'Frequency' => 'DESC',
 				'Term' => 'ASC'
 			),
-			'Term'
+			array('Term', 'HasResults')
 		);
 
 		// These will require display formatting.


### PR DESCRIPTION
Without the additional group-by, the following error is triggered in mysql 5.7+

```
Couldn't run query: SELECT Term, COUNT(*) AS Frequency, ((COUNT(*) * 100.00) / 4) AS FrequencyPercentage, AVG(Time) AS AverageTimeTaken, (Results > 0) AS Results FROM ExtensibleSearch WHERE (ExtensibleSearchPageID = 12544 AND Created BETWEEN '2016-11-01 00:00:00' AND '2016-12-01 00:00:00') GROUP BY Term ORDER BY Frequency DESC, Term ASC LIMIT 1000 Expression #5 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'mydb.ExtensibleSearch.Results' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```