### PR TITLE
fix(ExtensibleSearchPage): Fix bug where when `getSelectableFields` eturns a falsey value (ie. null), the `$fields + $selectable` operation gets a PHP error, "Invalid operand"

### DIFF
--- a/src/pages/ExtensibleSearchPage.php
+++ b/src/pages/ExtensibleSearchPage.php
@@ -432,6 +432,10 @@ class ExtensibleSearchPage extends \Page {
 			// Determine the search engine specific selectable fields.
 
 			$fields = singleton($this->SearchEngine)->getSelectableFields($this);
+			if (!$fields) {
+				// If null or falsey type, change to array
+				$fields = [];
+			}
 			return $fields + $selectable;
 		}
 		else if(($this->SearchEngine === 'Full-Text') && is_array($classes = Config::inst()->get(FulltextSearchable::class, 'searchable_classes')) && (count($classes) > 0)) {


### PR DESCRIPTION
fix(ExtensibleSearchPage): Fix bug where when `getSelectableFields` eturns a falsey value (ie. null), the `$fields + $selectable` operation gets a PHP error, "Invalid operand".

This was occuring during a dev/task that was writing lots of records.